### PR TITLE
Fix venv setup to configure proper venv path.

### DIFF
--- a/treadmill-aws/Makefile
+++ b/treadmill-aws/Makefile
@@ -52,6 +52,8 @@ install: venv sbin
 		    --no-index                  \
 		     kazoo[sasl]==2.4.0.dev0 Treadmill Treadmill_AWS
 	virtualenv-3 --relocatable $(VENV)
+	sed -i "s^$(RPMDIR)/BUILD/opt/treadmill^/opt/treadmill^g" \
+		$(RPMDIR)/BUILD/opt/treadmill/bin/activate*
 	cp service/*.service $(RPMDIR)/BUILD
 
 rpm:

--- a/treadmill-aws/sbin/start_node.sh
+++ b/treadmill-aws/sbin/start_node.sh
@@ -20,7 +20,9 @@ HOSTNAME=$(hostname --fqdn)
 export HOSTNAME
 
 # NOTE: Obtaining tickets is needed for the LDAP connection below.
+export KRB5CCNAME=$(mktemp)
 kinit -k -l 1d
+klist
 
 mkdir -pv ${INSTALL_DIR}
 


### PR DESCRIPTION
- search/replace venv to be /opt/treadmill - target install directory.
- start_node.sh - klist for debugging purposes.