### PR TITLE
Pin pip to v.10

### DIFF
--- a/treadmill-aws/Makefile
+++ b/treadmill-aws/Makefile
@@ -37,7 +37,8 @@ $(VENV)/bin/activate:
 	mkdir -p $(VENV)
 	virtualenv-3 $(VENV)                 \
 		&& source $(VENV)/bin/activate   \
-		&& pip install --no-cache-dir --no-index --find-links $(WHEELS) -U setuptools pip
+		&& pip install --update pip==10.0   \
+		&& pip install --no-cache-dir --no-index --find-links $(WHEELS) -U setuptools
 	virtualenv-3 --relocatable $(VENV)
 
 wheels: venv


### PR DESCRIPTION
Pip 18 throws an exception due to the environment HTTP proxy. V10 does not experience this issue.