### PR TITLE
Fix typo

### DIFF
--- a/treadmill-aws/sbin/start_openldap.sh
+++ b/treadmill-aws/sbin/start_openldap.sh
@@ -72,8 +72,8 @@ export KRB5_KTNAME=/var/spool/keytabs-services/ldap-${HOSTNAME}.keytab
 mkdir -pv ${INSTALL_DIR}
 mkdir -p /var/spool/keytabs-services/
 
-if [ ! -f ${KRB5_KTNAME}]; then
-	ipa-getkeytab -p ldap/${HOSTNAME}@${TREADMILL_KRB_REALM} -k ${KRB5_KTNAME}
+if [ ! -f ${KRB5_KTNAME} ]; then
+	ipa-getkeytab -p ldap/${HOSTNAME}.@${TREADMILL_KRB_REALM} -k ${KRB5_KTNAME}
 fi
 
 chown ${TREADMILL_PROID}:${TREADMILL_PROID} ${KRB5_KTNAME}


### PR DESCRIPTION
The hostname returned by $(hostname --fqdn) does not include a trailing period, which the IPA service does contain.