### PR TITLE
Discard tickets on restart

### DIFF
--- a/treadmill-aws/sbin/start_openldap.sh
+++ b/treadmill-aws/sbin/start_openldap.sh
@@ -56,6 +56,7 @@ echo "Installing Treadmill OpenLDAP: ${INSTALL_DIR}"
 
 HOSTNAME=$(hostname --fqdn)
 export HOSTNAME
+export KRB5CCNAME=$(mktemp)
 
 # Repeat kinit until successful
 until kinit -k -l 1d;

--- a/treadmill-scripts/configureldap.sh
+++ b/treadmill-scripts/configureldap.sh
@@ -115,7 +115,7 @@ trap cleanup EXIT
 # Write userdata to file
 cat << E%O%F > ${tmpdir}/LDAP.yaml
 ---
-treadmill_cell:
+treadmill_cell: openldap
 treadmill_dns_domain: ${TREADMILL_DNS_DOMAIN}
 treadmill_ldap: ${TREADMILL_LDAP}
 treadmill_ldap_suffix: ${TREADMILL_LDAP_SUFFIX}


### PR DESCRIPTION
Leaving treadmill_cell null results in issues with syscfg and presumably others downstream; I would like to use a dummy value until I have time to properly debug this. 

Like ZK, LDAP should get a fresh ticket cache on restart. This makes it easier to replace cluster members with identical hostnames and service principals.  